### PR TITLE
feat: add rate limiting functionality and update configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,5 @@ Wormhole will match destination of the request by name and proxy to the provided
 
 ### Future work
 - Documentation and set up examples
-- Rate limiting
 - Request authentication
 - Retry plugin

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,6 @@ import (
 )
 
 type Service struct {
-	Name         string `yaml:"name"`
 	UpstreamPath string `yaml:"upstream_path"`
 }
 
@@ -18,10 +17,21 @@ type Cors struct {
 	AllowHeaders string `yaml:"allow_headers"`
 }
 
+type PerIpAddress struct {
+	Enabled                bool `yaml:"enabled"`
+	CleanupIntervalSeconds int  `yaml:"cleanup_interval_seconds"`
+}
+
+type RateLimiting struct {
+	MaxCapacity  int64        `yaml:"max_capacity"`
+	PerIpAddress PerIpAddress `yaml:"per_ip_address"`
+}
+
 type Config struct {
-	Port     string             `yaml:"port"`
-	Services map[string]Service `yaml:"services"`
-	Cors     Cors               `yaml:"cors"`
+	Port         string             `yaml:"port"`
+	Services     map[string]Service `yaml:"services"`
+	Cors         Cors               `yaml:"cors"`
+	RateLimiting RateLimiting       `yaml:"rate_limiting"`
 }
 
 func GetConfig(configurationFilePath string) *Config {

--- a/middleware/rate_limiting.go
+++ b/middleware/rate_limiting.go
@@ -1,0 +1,142 @@
+package middleware
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/WeiLu1/wormhole/config"
+)
+
+type Visitor struct {
+	lastSeen    time.Time
+	leakyBucket *LeakyBucket
+}
+
+type RateLimiter struct {
+	visitors map[string]*Visitor
+	mu       sync.Mutex
+}
+
+func NewRateLimiter() *RateLimiter {
+	return &RateLimiter{
+		visitors: make(map[string]*Visitor),
+	}
+}
+
+func (rl *RateLimiter) CleanUpVisitors(cleanupIntervalSeconds int) {
+	ticker := time.NewTicker(time.Duration(cleanupIntervalSeconds) * time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		rl.mu.Lock()
+		for ip, v := range rl.visitors {
+			if time.Since(v.lastSeen) > time.Duration(cleanupIntervalSeconds)*time.Second {
+				log.Printf("Removing client %s", ip)
+				v.leakyBucket.stop <- struct{}{}
+				delete(rl.visitors, ip)
+			}
+		}
+		rl.mu.Unlock()
+	}
+}
+
+func (rl *RateLimiter) getOrCreateVisitorBucket(ip string, maxCapacity int64) *LeakyBucket {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	visitor, exists := rl.visitors[ip]
+	if !exists {
+		visitor = &Visitor{
+			lastSeen:    time.Now(),
+			leakyBucket: NewLeakyBucket(maxCapacity),
+		}
+		rl.visitors[ip] = visitor
+	} else {
+		visitor.lastSeen = time.Now()
+	}
+
+	return visitor.leakyBucket
+}
+
+type LeakyBucket struct {
+	maxCapacity int64
+	queue       chan struct{}
+	stop        chan struct{}
+}
+
+func NewLeakyBucket(maxCapacity int64) *LeakyBucket {
+	lb := &LeakyBucket{
+		maxCapacity: maxCapacity,
+		queue:       make(chan struct{}, maxCapacity),
+		stop:        make(chan struct{}),
+	}
+
+	go lb.leak()
+	return lb
+}
+
+// Checks whether or not a request can be processed by seeing if the capacity of the queue channel is full.
+func (lb *LeakyBucket) Allow() bool {
+	select {
+	case lb.queue <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+// This will remove a token from the queue in a time interval specified by the maximum amount of requests provided in the configuration per second.
+// Leaking will stop when the stop channel recieves
+func (lb *LeakyBucket) leak() {
+	ticker := time.NewTicker(time.Second / time.Duration(lb.maxCapacity))
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			select {
+			case <-lb.queue:
+			default:
+			}
+		case <-lb.stop:
+			return
+		}
+	}
+}
+
+func WithRateLimitingGlobal(h http.HandlerFunc, c config.RateLimiting, rateLimiter *RateLimiter) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		serve(rateLimiter, "global", c, w, h, r)
+	}
+}
+
+func WithRateLimitingPerVisitor(h http.HandlerFunc, c config.RateLimiting, rateLimiter *RateLimiter) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			log.Print(err.Error())
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		serve(rateLimiter, ip, c, w, h, r)
+	}
+}
+
+func serve(rateLimiter *RateLimiter, ip string, c config.RateLimiting, w http.ResponseWriter, h http.HandlerFunc, r *http.Request) {
+	lb := rateLimiter.getOrCreateVisitorBucket(ip, c.MaxCapacity)
+	if !lb.Allow() {
+		rateLimitExceededResponse(w)
+		return
+	}
+
+	h.ServeHTTP(w, r)
+}
+
+func rateLimitExceededResponse(w http.ResponseWriter) {
+	log.Printf("Too many requests for rate limiting capacity")
+	http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+}

--- a/sample.yaml
+++ b/sample.yaml
@@ -1,7 +1,7 @@
 port: 8880 
 
 services:
-  service-one:
+  service-one:  # name that needs to match the name of your service.
     upstream_path: "https://domain/service-one:8881" 
 
   service-two:
@@ -11,3 +11,10 @@ cors:
   allow_origins: "*"
   allow_methods: "*"
   allow_headers: "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization"
+
+
+rate_limiting:
+  max_capacity: 1
+  per_ip_address:
+    enabled: true
+    cleanup_interval_seconds: 10

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/WeiLu1/wormhole/config"
@@ -22,7 +23,27 @@ func (s *Server) Run() error {
 	mux := http.NewServeMux()
 	proxy := proxy.Proxy{Config: s.Config}
 
-	mux.HandleFunc("/*", mw.WithLogging(mw.WithCORS(proxy.HandleProxy, s.Config)))
+	rateLimitConfig := s.Config.RateLimiting
+	rateLimiter := mw.NewRateLimiter()
+	if rateLimitConfig.PerIpAddress.Enabled {
+		go rateLimiter.CleanUpVisitors(rateLimitConfig.PerIpAddress.CleanupIntervalSeconds)
+	}
 
+	handler := proxy.HandleProxy
+	handler = mw.WithCORS(handler, s.Config)
+
+	if rateLimitConfig.PerIpAddress.Enabled {
+		log.Print("Running with visitor rate limit")
+		handler = mw.WithRateLimitingPerVisitor(handler, rateLimitConfig, rateLimiter)
+	} else {
+		log.Print("Running with global rate limit")
+		handler = mw.WithRateLimitingGlobal(handler, rateLimitConfig, rateLimiter)
+	}
+
+	handler = mw.WithLogging(handler)
+
+	mux.HandleFunc("/*", handler)
+
+	log.Print("Running server...")
 	return http.ListenAndServe(":"+s.Config.Port, mux)
 }


### PR DESCRIPTION
Added rate limiting functionality to allow user to set a global or per ip address rate limit.

Rate limiting algorithm used is leaky bucket.

Channels used to block incoming requests if channel is full. 
Automatic cleaning of visitors done if `per_ip` is enabled. This means in the provided interval, if the client has been seen to be inactive it will be wiped from map.
Each visitor will have their own leaky bucket if `per_ip` enabled to enable rate limiting per ip address.

If global rate limiting enabled then server will only take a maximum of the provided value of requests per second from all clients.

