### PR TITLE
Feat/request auth middleware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+run-local:
+	set -a && source .env && go run main.go $(file)
+
+run-local-with-sample:
+	set -a && source .env && go run main.go sample.yaml
+
+test:
+	go test ./...

--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ Wormhole will match destination of the request by name and proxy to the provided
 
 ### Future work
 - Documentation and set up examples
-- Request authentication
 - Retry plugin
+- Load Balancing
+- IP whitelisting

--- a/config/config.go
+++ b/config/config.go
@@ -27,11 +27,16 @@ type RateLimiting struct {
 	PerIpAddress PerIpAddress `yaml:"per_ip_address"`
 }
 
+type Auth struct {
+	UseJwt bool `yaml:"use_jwt"`
+}
+
 type Config struct {
 	Port         string             `yaml:"port"`
 	Services     map[string]Service `yaml:"services"`
 	Cors         Cors               `yaml:"cors"`
 	RateLimiting RateLimiting       `yaml:"rate_limiting"`
+	Auth         Auth               `yaml:"auth"`
 }
 
 func GetConfig(configurationFilePath string) *Config {

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/WeiLu1/wormhole
 
 go 1.22.0
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require (
+	github.com/golang-jwt/jwt v3.2.2+incompatible
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,8 @@
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -1,0 +1,27 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/WeiLu1/wormhole/utils"
+)
+
+func WithAuth(h http.HandlerFunc, jwtProcessor *utils.JWTProcessor) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		authToken := r.Header.Get("Authorization")
+		if len(authToken) == 0 {
+			http.Error(w, "No Authorization header", http.StatusBadRequest)
+			return
+		}
+
+		authTokenRaw := strings.Split(authToken, " ")[1]
+		_, err := jwtProcessor.VerifyToken(authTokenRaw)
+		if err != nil {
+			http.Error(w, "Authorization not valid", http.StatusUnauthorized)
+			return
+		}
+
+		h.ServeHTTP(w, r)
+	}
+}

--- a/middleware/rate_limiting.go
+++ b/middleware/rate_limiting.go
@@ -137,6 +137,6 @@ func serve(rateLimiter *RateLimiter, ip string, c config.RateLimiting, w http.Re
 }
 
 func rateLimitExceededResponse(w http.ResponseWriter) {
-	log.Printf("Too many requests for rate limiting capacity")
+	log.Print("Too many requests for rate limiting capacity")
 	http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
 }

--- a/sample.yaml
+++ b/sample.yaml
@@ -12,9 +12,11 @@ cors:
   allow_methods: "*"
   allow_headers: "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization"
 
-
 rate_limiting:
   max_capacity: 1
   per_ip_address:
     enabled: true
     cleanup_interval_seconds: 10
+
+auth:
+  use_jwt: true

--- a/server/server.go
+++ b/server/server.go
@@ -3,10 +3,12 @@ package server
 import (
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/WeiLu1/wormhole/config"
 	mw "github.com/WeiLu1/wormhole/middleware"
 	"github.com/WeiLu1/wormhole/proxy"
+	"github.com/WeiLu1/wormhole/utils"
 )
 
 type Server struct {
@@ -38,6 +40,11 @@ func (s *Server) Run() error {
 	} else {
 		log.Print("Running with global rate limit")
 		handler = mw.WithRateLimitingGlobal(handler, rateLimitConfig, rateLimiter)
+	}
+
+	if s.Config.Auth.UseJwt {
+		jwtProcessor := utils.NewJWTProcessor(os.Getenv("JWT_SECRET"))
+		handler = mw.WithAuth(handler, jwtProcessor)
 	}
 
 	handler = mw.WithLogging(handler)

--- a/utils/token.go
+++ b/utils/token.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"errors"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+)
+
+var ErrInvalidToken = errors.New("invalid token")
+var ErrExpiredToken = errors.New("expired token")
+
+type Claims struct {
+	IssuedAt  time.Time `json:"issued_at"`
+	ExpiredAt time.Time `json:"expired_at"`
+}
+
+func (c *Claims) Valid() error {
+	if time.Now().After(c.ExpiredAt) {
+		return ErrExpiredToken
+	}
+	return nil
+}
+
+type JWTProcessor struct {
+	secretKey string
+}
+
+func (j *JWTProcessor) VerifyToken(token string) (*Claims, error) {
+	keyFunc := func(token *jwt.Token) (any, error) {
+		_, ok := token.Method.(*jwt.SigningMethodHMAC)
+		if !ok {
+			return nil, ErrInvalidToken
+		}
+		return []byte(j.secretKey), nil
+	}
+
+	jwtToken, err := jwt.ParseWithClaims(token, &Claims{}, keyFunc)
+	if err != nil {
+		verr, ok := err.(*jwt.ValidationError)
+		if ok && errors.Is(verr.Inner, ErrExpiredToken) {
+			return nil, ErrExpiredToken
+		}
+		return nil, ErrInvalidToken
+	}
+
+	claims, ok := jwtToken.Claims.(*Claims)
+	if !ok {
+		return nil, ErrInvalidToken
+	}
+
+	return claims, nil
+}
+
+func NewJWTProcessor(secretKey string) *JWTProcessor {
+	return &JWTProcessor{secretKey: secretKey}
+}

--- a/utils/token_test.go
+++ b/utils/token_test.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+)
+
+const testSecretKey = "123456789012345678901234456789012"
+
+func createToken() (string, *Claims) {
+	claims := &Claims{
+		IssuedAt:  time.Now(),
+		ExpiredAt: time.Now().Add(10 * time.Minute),
+	}
+
+	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	token, _ := jwtToken.SignedString([]byte(testSecretKey))
+
+	return token, claims
+}
+
+func TestVerifyToken(t *testing.T) {
+	token, _ := createToken()
+
+	jwtProcessor := NewJWTProcessor(testSecretKey)
+	claims, err := jwtProcessor.VerifyToken(token)
+
+	if err != nil {
+		t.Errorf("verify token did not work")
+	}
+
+	if claims == nil {
+		t.Errorf("claims is empty")
+	}
+}


### PR DESCRIPTION
Created Authorization middleware that checks jwt before allowing request to progress. Option is available to turn off feature in the configuration. 

Secret key must be provided in environment variables or secret manager.
Test token can be obtained in unit test.