### PR TITLE
feat: whitelist ipv4 and ipv6 addresses if provided in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,17 @@ service-one:
 Wormhole will match destination of the request by name and proxy to the provided upstream path.
 
 
+## Features
 
-### Future work
-- Documentation and set up examples
+### CORS
+
+### Rate Limiting
+
+### Authentication
+
+### IP Whitelisting
+
+
+## Future work
 - Retry plugin
-- Load Balancing
-- IP whitelisting
+- Documentation and set up examples

--- a/config/config.go
+++ b/config/config.go
@@ -31,12 +31,17 @@ type Auth struct {
 	UseJwt bool `yaml:"use_jwt"`
 }
 
+type Whitelist struct {
+	Allow []string `yaml:"allow"`
+}
+
 type Config struct {
 	Port         string             `yaml:"port"`
 	Services     map[string]Service `yaml:"services"`
 	Cors         Cors               `yaml:"cors"`
 	RateLimiting RateLimiting       `yaml:"rate_limiting"`
 	Auth         Auth               `yaml:"auth"`
+	Whitelist    Whitelist          `yaml:"whitelist"`
 }
 
 func GetConfig(configurationFilePath string) *Config {

--- a/middleware/whitelist.go
+++ b/middleware/whitelist.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"errors"
+	"log"
+	"net"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+var ErrInvalidAddress = errors.New("invalid address")
+
+func WithWhitelisting(h http.HandlerFunc, allowedAddresses []string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		addr, err := getRealAddress(r)
+		if err != nil {
+			log.Print("IP address not valid")
+			http.Error(w, "", http.StatusUnauthorized)
+			return
+		}
+
+		if !slices.Contains(allowedAddresses, addr) {
+			log.Print("IP address not allowed")
+			http.Error(w, "", http.StatusUnauthorized)
+			return
+		}
+
+		h.ServeHTTP(w, r)
+	}
+}
+
+func getRealAddress(r *http.Request) (string, error) {
+	remoteIp, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return "", ErrInvalidAddress
+	}
+
+	if xff := strings.Trim(r.Header.Get("X-Forwarded-For"), ","); len(xff) > 0 {
+		addrs := strings.Split(xff, ",")
+		lastForwarded := addrs[len(addrs)-1]
+
+		if ip := net.ParseIP(lastForwarded); ip != nil {
+			remoteIp = ip.String()
+		}
+	}
+
+	return remoteIp, nil
+}

--- a/sample.yaml
+++ b/sample.yaml
@@ -20,3 +20,9 @@ rate_limiting:
 
 auth:
   use_jwt: true
+
+whitelist:
+  allow: 
+    - 127.0.0.1
+    - 192.168.1.10
+    - ::1

--- a/server/server.go
+++ b/server/server.go
@@ -47,6 +47,10 @@ func (s *Server) Run() error {
 		handler = mw.WithAuth(handler, jwtProcessor)
 	}
 
+	if allowAddrs := s.Config.Whitelist.Allow; allowAddrs != nil {
+		handler = mw.WithWhitelisting(handler, allowAddrs)
+	}
+
 	handler = mw.WithLogging(handler)
 
 	mux.HandleFunc("/*", handler)


### PR DESCRIPTION
Users can choose to deny all requests that do not come from the approved list of IP addresses in the config file. 
Addresses can be ipv4 or ipv6. 